### PR TITLE
explicit-function-return-type rule off

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -18,7 +18,7 @@ module.exports = {
     ],
     camelcase: 'off',
     '@typescript-eslint/consistent-type-assertions': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'warn',
+    '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/member-delimiter-style': 'off',
     'no-array-constructor': 'off',
     '@typescript-eslint/no-array-constructor': 'error',


### PR DESCRIPTION
# What
@typescript-eslint/explicit-function-return-type 룰을 껐습니다.
사유: https://noogoonaa.tistory.com/63