### PR TITLE
Max classes per file off

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
     'class-methods-use-this': 0,
+    'max-classes-per-file': 'off'
   }
 };

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -7,5 +7,6 @@ module.exports = {
     'import/imports-first': 'off',
     'import/extensions': 'off',
     'import/no-webpack-loader-syntax': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/rules/react-hooks.js
+++ b/rules/react-hooks.js
@@ -2,6 +2,5 @@ module.exports = {
   plugins: ['react-hooks'],
   rules: {
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
   },
 };


### PR DESCRIPTION
## Summary
https://eslint.org/docs/latest/rules/max-classes-per-file
https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md
[react-hooks/exhaustive-deps 룰 삭제](https://github.com/bclabs-org/eslint-config-bclabs/commit/418d5176c1da59790e4e613e9fb7e9d37d48b242)

## Why need this changes?
구두로 이야기나눈 룰 3가지 off

한 파일당 class 하나로 강제하는 룰 -> 불편해서 off
export default -> 불편해서 off
exhaustive-deps -> 역시 불편하고 개발상 큰 문제가 되지 않아서 off

## Link for the issue(Optional)
