### PR TITLE
react-hooks/exhaustive-deps off

### DIFF
--- a/rules/react-hooks.js
+++ b/rules/react-hooks.js
@@ -2,5 +2,6 @@ module.exports = {
   plugins: ['react-hooks'],
   rules: {
     'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'off',
   },
 };


### PR DESCRIPTION
## Summary
https://github.com/bclabs-org/eslint-config-bclabs/pull/12

## Why need this changes?
react-hooks/exhaustive-deps룰 off로 설정해야 꺼지길래 다시 수정했습니다.

## Link for the issue(Optional)
