### PR TITLE
console error, info, warn 허용하도록 수정

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: [
     './best-practices',
+    './errors',
     './es6',
     './imports',
     './react',

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'no-console': ['warn', { allow: ['warn', 'error', 'info'] }]
+  }
+};


### PR DESCRIPTION
## Summary
전에 console는 error, info, warn 등만 사용하자고 했는데, error등도 린트에 걸리고 있어서 수정했습니다.
## Why need this changes?

## Link for the issue(Optional)
