### PR TITLE
Fix/"@typescript_eslint no-shadow 와 충돌나는 일반 no-shadow 룰 off 로 변경"

### DIFF
--- a/recommends/eslint-config-airbnb-base/variables.js
+++ b/recommends/eslint-config-airbnb-base/variables.js
@@ -31,7 +31,7 @@ module.exports = {
     ].concat(confusingBrowserGlobals),
 
     // disallow declaration of variables already declared in the outer scope
-    'no-shadow': 'error',
+    'no-shadow': 'off',
 
     // disallow shadowing of names such as arguments
     'no-shadow-restricted-names': 'error',

--- a/recommends/eslint-config-airbnb-base/variables.js
+++ b/recommends/eslint-config-airbnb-base/variables.js
@@ -31,7 +31,7 @@ module.exports = {
     ].concat(confusingBrowserGlobals),
 
     // disallow declaration of variables already declared in the outer scope
-    'no-shadow': 'off',
+    'no-shadow': 'error',
 
     // disallow shadowing of names such as arguments
     'no-shadow-restricted-names': 'error',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -30,6 +30,7 @@ module.exports = {
     '@typescript-eslint/no-misused-new': 'error',
     '@typescript-eslint/no-namespace': 'error',
     '@typescript-eslint/no-non-null-assertion': 'warn',
+    'no-shadow': 'off', // replaced by '@typescript-eslint/no-shadow'
     '@typescript-eslint/no-shadow': [
       'error',
       {


### PR DESCRIPTION
## Summary
- eslint no-shadow: off 로 변경
## Why need this changes?
- 일반 eslint no-shadow 룰과 @typescript-eslint/no-shadow 룰이 충돌하여 typescript enum type 사용불가
## Link for the issue(Optional)
- Typescript-eslint no-shadow 룰 사용방법 변경사항 관련 PR
https://github.com/typescript-eslint/typescript-eslint/pull/2039/files#diff-3aee95c4408bebf6353dffa360b480cda1d9de6fec7e60d58cedc790f51ac194R8-R16